### PR TITLE
Fix detect version

### DIFF
--- a/webviewloader/module.go
+++ b/webviewloader/module.go
@@ -24,9 +24,10 @@ var (
 )
 
 // CompareBrowserVersions will compare the 2 given versions and return:
-//  -1 = v1 < v2
-//   0 = v1 == v2
-//   1 = v1 > v2
+//
+//	-1 = v1 < v2
+//	 0 = v1 == v2
+//	 1 = v1 > v2
 func CompareBrowserVersions(v1 string, v2 string) (int, error) {
 
 	_v1, err := windows.UTF16PtrFromString(v1)
@@ -82,7 +83,7 @@ func GetInstalledVersion() (string, error) {
 			uint64(uintptr(unsafe.Pointer(nil))),
 			uint64(uintptr(unsafe.Pointer(&result))))
 	} else {
-		_, _, err = nativeCompareBrowserVersions.Call(
+		_, _, err = nativeGetAvailableCoreWebView2BrowserVersionString.Call(
 			uintptr(unsafe.Pointer(nil)),
 			uintptr(unsafe.Pointer(&result)))
 	}

--- a/webviewloader/module.go
+++ b/webviewloader/module.go
@@ -96,7 +96,7 @@ func GetInstalledVersion() (string, error) {
 			uintptr(unsafe.Pointer(&result)))
 	}
 	defer windows.CoTaskMemFree(unsafe.Pointer(result)) // Safe even if result is nil
-	if hr != 0 {
+	if hr != uintptr(windows.S_OK) {
 		if hr&0xFFFF == uintptr(windows.ERROR_FILE_NOT_FOUND) {
 			// The lower 16-bits (the error code itself) of the HRESULT is ERROR_FILE_NOT_FOUND which means the system isn't installed.
 			return "", nil // Return a blank string but no error since we successfully detected no install.


### PR DESCRIPTION
Resolves a few issues with version detection:
* Code was looking at err (which internally is based off of [GetLastError](https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror), but the API instead returns an HRESULT.
* What appears to be copy pasted code retained a reference to `nativeCompareBrowserVersions` in a different function

Formatting change to godoc comment is from newer tooling changing the default formatting.